### PR TITLE
Re-generate gcode before preview/start/export 

### DIFF
--- a/printrun/burner.py
+++ b/printrun/burner.py
@@ -1611,6 +1611,12 @@ class PronterWindow(MainWindow, pronsole.pronsole):
     #  --------------------------------------------------------------
 
     def savefile(self, event):
+        filename =  self.FilePathLabel.GetValue()
+        if (not filename) or filename == '':
+            return
+
+        self.convert_png2gcode( filename)
+
         if not self.pngLoaded:
             return
         basedir = self.settings.last_file_path
@@ -2579,6 +2585,9 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         #self.p.runSmallScript(self.previewfilename)
 
     def LaserStart(self, event):
+        filename =  self.FilePathLabel.GetValue()
+        if (not filename) or filename == '':
+            return
         if (self.pngLoaded==False):
             return
         self.load_gcode_and_print_async('out.gcode')

--- a/printrun/burner.py
+++ b/printrun/burner.py
@@ -2578,6 +2578,11 @@ class PronterWindow(MainWindow, pronsole.pronsole):
             self.onecmd(line)
 
     def LaserPreview(self, event):
+        filename =  self.FilePathLabel.GetValue()
+        if (not filename) or filename == '':
+            return
+        self.convert_png2gcode( filename)
+
         if (self.pngLoaded==False):
             return
         self.isPreview = True;
@@ -2588,8 +2593,10 @@ class PronterWindow(MainWindow, pronsole.pronsole):
         filename =  self.FilePathLabel.GetValue()
         if (not filename) or filename == '':
             return
+        self.convert_png2gcode( filename)
         if (self.pngLoaded==False):
             return
+
         self.load_gcode_and_print_async('out.gcode')
 
     def update_focaldist(self, focaldist):


### PR DESCRIPTION
Regenerate gcode before laser start and exporting gcode in case user has changed setting. It does not care about if the async loading is completed or not as it is not that important(leave for future enhancement).
